### PR TITLE
Added fix for proxy to run properly in mac environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ For transparently rewriting HTTP/HTTPS responses. The mitmproxy plugin lets ever
 
 ## Pre-requisites
 
-* [`mitmproxy` V4](https://mitmproxy.org/) must be installed and runnable from the terminal. The install method cannot be a prebuilt binary or homebrew, since those packages are missing the Python websockets module. Install via `pip` or from source.
-* Python 3.6, since we use the new async/await syntax in the mitmproxy plugin
+* [`mitmproxy` V9](https://mitmproxy.org/) must be installed and runnable from the terminal. The install method cannot be a prebuilt binary or homebrew, since those packages are missing the Python websockets module. Install via `pip` or from source.
+* Python 3.6 and above, since we use the new async/await syntax in the mitmproxy plugin
 * `pip3 install websockets`
 
 Maven:
@@ -35,13 +35,13 @@ Maven:
 <dependency>
   <groupId>io.appium</groupId>
   <artifactId>mitmproxy-java</artifactId>
-  <version>1.6.2</version>
+  <version>2.0.2</version>
 </dependency>
 ```
 
 Gradle:
 ```
-testCompile group: 'io.appium', name: 'mitmproxy-java', version: '1.6.1'
+testCompile group: 'io.appium', name: 'mitmproxy-java', version: '2.0.0'
 ```
 
 ## Usage
@@ -67,10 +67,16 @@ proxy.start();
 // do stuff
 
 proxy.stop();
-
 ```
 
-See AppriumPro article for more guidelines: https://appiumpro.com/editions/65
+If the above code doesn't work, and you are getting 
+`Error=2, No such file or directory` please re-check your mitmdump path in new MitmproxyJava initialization.
+You can get mitmdump path using below command:
+```shell
+whereis mitmdump
+```
+
+See AppiumPro article for more guidelines: https://appiumpro.com/editions/65
 Example can be found here: https://github.com/cloudgrey-io/appiumpro/blob/master/java/src/test/java/Edition065_Capture_Network_Requests.java
 
 ## Your Java code is bad and you should feel bad

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Maven:
 
 Gradle:
 ```
-testCompile group: 'io.appium', name: 'mitmproxy-java', version: '2.0.0'
+testCompile group: 'io.appium', name: 'mitmproxy-java', version: '2.0.2'
 ```
 
 ## Usage

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'io.appium'
-version = '2.0.1'
+version = '2.0.2'
 archivesBaseName = 'mitmproxy-java'
 
 sourceCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,10 @@ artifacts {
     archives javadocJar, sourcesJar
 }
 signing {
-    sign configurations.archives
+    setRequired {
+        // signing is only required if the artifacts are to be published
+        sign configurations.archives
+    }
 }
 
 
@@ -60,10 +63,10 @@ uploadArchives {
 
             // Destination
             repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
+                authentication(userName: hasProperty('ossrhUsername'), password: hasProperty('ossrhPassword'))
             }
             snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
+                authentication(userName: hasProperty('ossrhUsername'), password: hasProperty('ossrhPassword'))
             }
 
             // Add required metadata to POM

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {

--- a/src/main/resources/scripts/proxy.py
+++ b/src/main/resources/scripts/proxy.py
@@ -150,7 +150,7 @@ class WebSocketAdapter:
             new_metadata = message_response[0]
             new_body = message_response[1]
 
-            flow.response = http.HTTPResponse.make(
+            flow.response = http.Response.make(
                 new_metadata['status_code'],
                 new_body,
                 map(convert_headers_to_bytes, new_metadata['headers'])
@@ -198,7 +198,7 @@ class WebSocketAdapter:
 
         #print("Prepping response!")
 
-        flow.response = http.HTTPResponse.make(
+        flow.response = http.Response.make(
             new_metadata['status_code'],
             new_body,
             map(convert_headers_to_bytes, new_metadata['headers'])

--- a/src/test/java/io/appium/mitmproxy/MitmproxyJavaTest.java
+++ b/src/test/java/io/appium/mitmproxy/MitmproxyJavaTest.java
@@ -29,7 +29,6 @@ public class MitmproxyJavaTest {
     }
     @Test
     public void ConstructorTest() throws InterruptedException, IOException, TimeoutException {
-        System.out.println();
         MitmproxyJava proxy = new MitmproxyJava(MITMDUMP_PATH, (InterceptedMessage m) -> {
             System.out.println(m.getRequest().getUrl());
             return m;

--- a/src/test/java/io/appium/mitmproxy/MitmproxyJavaTest.java
+++ b/src/test/java/io/appium/mitmproxy/MitmproxyJavaTest.java
@@ -19,10 +19,17 @@ import static org.mockito.Mockito.verify;
 public class MitmproxyJavaTest {
 
     //private static final String MITMDUMP_PATH = "C:\\Python37\\Scripts\\mitmdump.exe";
-    private static final String MITMDUMP_PATH = "/usr/local/bin/mitmdump";
+    private static final String MITMDUMP_PATH = getMITMDumpPath();
 
+    static String getMITMDumpPath(){
+        if(System.getProperty("os.name").contains("Mac")){
+            return "/opt/homebrew/bin/mitmdump";
+        }
+        return "/usr/local/bin/mitmdump";
+    }
     @Test
     public void ConstructorTest() throws InterruptedException, IOException, TimeoutException {
+        System.out.println();
         MitmproxyJava proxy = new MitmproxyJava(MITMDUMP_PATH, (InterceptedMessage m) -> {
             System.out.println(m.getRequest().getUrl());
             return m;


### PR DESCRIPTION
Fix contains 5 major changes for proxy to run perfectly on mac. This is my first PR, please correct/guide me if there is any issues with the PR. 


### 1. Removed JCenter
```
Builds will no longer be able to resolve artifacts from JCenter after February 1st, 2022 
```

### 2. Used hasProperty instead of directly accessing property in authentication
Build was failing because no property was set for `ossrhUsername` and `ossrhPassword`
```
A problem occurred evaluating root project 'mitmproxy-java'.
> Could not get unknown property 'ossrhUsername' for object of type org.gradle.api.publication.maven.internal.deployer.DefaultGroovyMavenDeployer.
```

### 3. Moved sign configurations.archives inside setRequired block
Signing is only required if the artifacts are to be published.
```
Execution failed for task ':signArchives'.
> Cannot perform signing task ':signArchives' because it has no configured signatory
```

### 4. Replaced http.HTTPResponse.make with http.Response.make as The mitmproxy API seems to have changed and the syntax is now http.Response.make()

```
[Thread-14] INFO io.appium.mitmproxy.MitmproxyJava - [11:32:53.624] Addon error: Traceback (most recent call last):
[Thread-14] INFO io.appium.mitmproxy.MitmproxyJava -   File "/private/var/folders/q3/vj5bmx6171b_wxhtdtq3th2c0000gn/T/mitmproxy-python-plugin3410838807867045242.py", line 201, in response
[Thread-14] INFO io.appium.mitmproxy.MitmproxyJava -     flow.response = http.HTTPResponse.make(
[Thread-14] INFO io.appium.mitmproxy.MitmproxyJava - AttributeError: module 'mitmproxy.http' has no attribute 'HTTPResponse'
[Thread-14] INFO io.appium.mitmproxy.MitmproxyJava - 127.0.0.1:50785: GET http://appium.io/
[Thread-14] INFO io.appium.mitmproxy.MitmproxyJava -               << 200 OK 4.5k
```

### 5. Updated MITMDUMP_PATH for mac
```
[Test worker] INFO io.appium.mitmproxy.MitmproxyJava - Starting mitmproxy on port 8080
[WebSocketSelector-22] INFO org.java_websocket.server.WebSocketServer - websocket server started successfully
[Test worker] ERROR org.zeroturnaround.exec.ProcessExecutor - Could not start process:
java.io.IOException: Cannot run program "/usr/local/bin/mitmdump": error=2, No such file or directory
```


Post all fixed all tests are passing perfectly in mac machine
```
11:42:38 AM: Executing 'build'...

Starting Gradle Daemon...
Gradle Daemon started in 461 ms
> Task :compileJava UP-TO-DATE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :jar UP-TO-DATE
> Task :javadoc UP-TO-DATE
> Task :javadocJar UP-TO-DATE
> Task :sourcesJar UP-TO-DATE
> Task :assemble UP-TO-DATE
> Task :compileTestJava UP-TO-DATE
> Task :processTestResources NO-SOURCE
> Task :testClasses UP-TO-DATE
> Task :test
> Task :check
> Task :build

BUILD SUCCESSFUL in 7s
8 actionable tasks: 1 executed, 7 up-to-date
11:42:45 AM: Execution finished 'build'.
```